### PR TITLE
[質問] users_spec.rbの「新規作成したタスクが表示される」でtask.titleがすでに登録されているというエラーが出る件について

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,12 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails', '~> 4.0.2'
   gem 'factory_bot_rails'
+  gem 'pry-rails'
+end
+
+group :test do
+  gem 'capybara'
+  gem 'webdrivers'
 end
 
 group :development do
@@ -25,7 +31,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'pry-rails'
   gem 'pry-byebug'
   gem 'pry-doc'
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
     bcrypt (3.1.13)
@@ -56,6 +58,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    capybara (3.27.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     code_analyzer (0.4.8)
       sexp_processor
     coderay (1.1.2)
@@ -132,6 +143,7 @@ GEM
       yard (~> 0.9.11)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (3.1.1)
     puma (3.12.6)
     rack (2.2.2)
     rack-test (1.1.0)
@@ -173,6 +185,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (1.6.0)
     require_all (2.0.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -200,6 +213,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -211,6 +225,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
     sorcery (0.15.0)
       bcrypt (~> 3.1)
@@ -241,9 +258,15 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.5.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     yard (0.9.20)
 
 PLATFORMS
@@ -254,6 +277,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
+  capybara
   coffee-rails (~> 4.2)
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
@@ -273,6 +297,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 RUBY VERSION
    ruby 2.6.4p104

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :task do
     sequence(:title) { |n| "書類作成#{n}" }
     content {"取引先に書類を作成する"}
-    status {"todo"}
+    status { 'todo' }
     deadline { 1.week.from_now }
     association :user
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "example#{n}@example.com"}
-    password {"example"}
-    password_confirmation {"example"}
+    password {'example'}
+    password_confirmation {'example'}
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'validate', type: :model do
   it 'タイトルがなければ無効な状態であること' do
     task_without_title = FactoryBot.build(:task, title: "")
     expect(task_without_title).to be_invalid
-    expect(task_without_title.errors[:title]).to include("can't be blank")
+    expect(task_without_title.errors[:title]).to eq ["can't be blank"]
   end
 
   it '重複したタイトルなら無効な状態であること' do
@@ -21,7 +21,7 @@ RSpec.describe 'validate', type: :model do
   it 'statusがなければ無効な状態であること' do
     task_without_status = FactoryBot.build(:task, status: nil)
     expect(task_without_status).to be_invalid
-    expect(task_without_status.errors[:status]).to include("can't be blank")
+    expect(task_without_status.errors[:status]).to eq ["can't be blank"]
   end
 
   it '他のタイトルであれば有効な状態であること' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -31,14 +31,12 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.use_transactional_fixtures = true
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
-
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
@@ -62,4 +60,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include LoginModules
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+  config.filter_run_when_matching :focus
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
@@ -52,8 +53,6 @@ RSpec.configure do |config|
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
@@ -86,7 +85,6 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = :random
-
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value

--- a/spec/support/login_modules.rb
+++ b/spec/support/login_modules.rb
@@ -1,0 +1,13 @@
+module LoginModule
+    def login(user)
+        visit login_path
+        fill_in 'Email', with: user.email
+        fill_in 'Password', with: 'example'
+        click_button 'Login'
+    end
+
+    def logout(user)
+        visit root_path
+        click_on 'Logout'
+    end
+end

--- a/spec/support/login_modules.rb
+++ b/spec/support/login_modules.rb
@@ -1,4 +1,4 @@
-module LoginModule
+module LoginModules
     def login(user)
         visit login_path
         fill_in 'Email', with: user.email

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe 'Tasks', type: :system do
+
+    let(:task){ create(:task) }
+    let(:user){ create(:user) }
+
+    describe 'ログイン前' do
+        context 'タスク新規作成ページにアクセス' do
+            it '新規作成ページへのアクセスに失敗する' do
+                visit new_task_path
+                expect(current_path).to eq login_path
+                expect(page).to have_content 'Login required'
+            end
+        end
+        context 'ユーザーのタスク編集ページにアクセス' do
+            it 'タスク編集ページへのアクセスに失敗する' do
+                visit edit_task_path(user)
+                expect(current_path).to eq login_path
+                expect(page).to have_content 'Login required'
+            end
+        end
+    end
+
+    describe 'ログイン後' do
+
+        before do
+            login(user)
+        end
+        let!(:other_task){ create(:task) }
+
+        describe 'タスクの新規登録' do
+            context 'フォームの入力値が正常' do
+                it 'タスクの新規登録が成功する' do
+                    visit new_task_path
+                    fill_in 'Title', with: 'first_task'
+                    fill_in 'Content', with: 'first_content'
+                    select 'todo', from: 'Status'
+                    fill_in 'Deadline', with: task.deadline
+                    click_button 'Create Task'
+                    expect(current_path).to eq task_path(task.user_id)
+                    expect(page).to have_content "Task was successfully created."
+                end
+            end
+            context 'タイトルが未入力' do
+                it 'タスクの新規登録が失敗する' do
+                    visit new_task_path
+                    fill_in 'Title', with: ''
+                    fill_in 'Content', with: 'second_content'
+                    select 'todo', from: 'Status'
+                    fill_in 'Deadline', with: task.deadline
+                    click_button 'Create Task'
+                    expect(current_path).to eq tasks_path
+                    expect(page).to have_content "Title can't be blank"
+                end
+            end
+
+            context 'タイトルが重複している' do
+                it 'タスクの新規登録が失敗する' do
+                    visit new_task_path
+                    fill_in 'Title', with: other_task.title
+                    fill_in 'Content', with: 'therd_content'
+                    select 'todo', from: 'Status'
+                    fill_in 'Deadline', with: task.deadline
+                    click_button 'Create Task'
+                    expect(current_path).to eq tasks_path
+                    expect(page).to have_content "Title has already been taken"
+                end
+            end
+        end
+
+        describe 'タスクの編集ができる' do
+
+            let!(:task){ create(:task, user_id: user.id)}
+
+            context 'フォームの入力値が正常' do
+                it 'タスクの編集が成功する' do
+                    visit edit_task_path(task)
+                    fill_in 'Title', with: 'Update_title'
+                    select :done, from: 'Status'
+                    click_button 'Update Task'
+                    expect(current_path).to eq task_path(task)
+                    expect(page).to have_content "Task was successfully updated"
+                end
+            end
+
+            context 'タイトルが未入力' do
+                it 'タスクの編集が失敗する' do
+                    visit tasks_path
+                    click_on 'Edit'
+                    fill_in 'Title', with: ""
+                    click_button 'Update Task'
+                    expect(current_path).to eq task_path(task)
+                    expect(page).to have_content "Title can't be blank"
+                end
+            end
+        end
+
+        describe 'タスクの削除ができる' do
+
+            let!(:task){create(:task, user_id: user.id)}
+
+            context 'デストロイボタンをクリック' do
+                it 'タスクの削除が成功する' do
+                    visit tasks_path
+                    click_on 'Destroy'
+                    expect(page.accept_confirm).to eq "Are you sure?"
+                    expect(current_path).to eq tasks_path
+                    expect(page).to have_content 'Task was successfully destroyed'
+                end
+            end
+        end
+    end
+end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'UserSessions', type: :system do
+
+    let(:user_a){ FactoryBot.create(:user) }
+
+    describe 'ログイン前' do
+        context 'フォームの入力値が正常' do
+            it 'ログイン処理が成功する' do
+                visit login_path
+                fill_in 'Email', with: user_a.email
+                fill_in 'Password', with: 'example'
+                click_button 'Login'
+                expect(page).to have_content 'Login successful'
+            end
+        end
+        context 'フォームが未入力' do
+            it 'ログイン処理が失敗する' do
+                visit login_path
+                fill_in 'Email', with: ''
+                fill_in 'Password', with: ''
+                click_button 'Login'
+                expect(page).to have_content 'Login failed'
+            end
+        end
+    end
+
+    describe 'ログイン後' do
+            before do
+                login(user_a)
+            end
+        context 'ログアウトボタンをクリック' do
+            it 'ログアウト処理が成功する' do
+                visit root_path
+                click_on 'Logout'
+                expect(page).to have_content 'Logged out'
+            end
+        end
+    end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,19 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  let(:user_a){ build(:user) }
+
   let(:user){ create(:user) }
   let(:other_user){ create(:user) }
-  let(:task){ create(:task)}
 
   describe 'ログイン前' do
     describe 'ユーザー新規登録'
       context 'フォームの入力値が正常' do
         it 'ユーザーの新規作成が成功する' do
           visit sign_up_path
-          fill_in "Email", with: user_a.email
-          fill_in "Password", with: user_a.password
-          fill_in "Password confirmation", with: user_a.password_confirmation
+          fill_in "Email", with: 'admin@example.com'
+          fill_in "Password", with: 'admin'
+          fill_in "Password confirmation", with: 'admin'
           click_button 'SignUp'
           expect(current_path).to eq login_path
           expect(page).to have_content 'User was successfully created.'
@@ -24,8 +23,8 @@ RSpec.describe "Users", type: :system do
         it 'ユーザーの新規作成が失敗する' do
           visit sign_up_path
           fill_in 'Email', with: ''
-          fill_in 'Password', with: user_a.password
-          fill_in 'Password confirmation', with: user_a.password_confirmation
+          fill_in 'Password', with: 'admin'
+          fill_in 'Password confirmation', with: 'admin'
           click_button 'SignUp'
           expect(current_path).to eq users_path
           expect(page).to have_content "Email can't be blank"
@@ -95,13 +94,10 @@ RSpec.describe "Users", type: :system do
     describe 'マイページ' do
       context 'タスクを作成' do
         it '新規作成したタスクが表示される' do
-          visit new_task_path
-          fill_in 'Title', with: task.title
-          fill_in 'Content', with: task.content
-          select task.status, from: 'Status'
-          fill_in 'Deadline', with: task.deadline
-          click_button 'Create Task'
-          expect(page).to have_content "Task was successfully created."
+          create(:task, title: 'タスク', status: :todo, user_id: user.id)
+          visit user_path(user)
+          expect(page).to have_content "タスク"
+          expect(page).to have_content 'todo'
         end
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  let(:user_a){ build(:user) }
+  let(:user){ create(:user) }
+  let(:other_user){ create(:user) }
+  let(:task){ create(:task)}
+
+  describe 'ログイン前' do
+    describe 'ユーザー新規登録'
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの新規作成が成功する' do
+          visit sign_up_path
+          fill_in "Email", with: user_a.email
+          fill_in "Password", with: user_a.password
+          fill_in "Password confirmation", with: user_a.password_confirmation
+          click_button 'SignUp'
+          expect(current_path).to eq login_path
+          expect(page).to have_content 'User was successfully created.'
+        end
+      end
+
+      context 'メールアドレレスが未入力' do
+        it 'ユーザーの新規作成が失敗する' do
+          visit sign_up_path
+          fill_in 'Email', with: ''
+          fill_in 'Password', with: user_a.password
+          fill_in 'Password confirmation', with: user_a.password_confirmation
+          click_button 'SignUp'
+          expect(current_path).to eq users_path
+          expect(page).to have_content "Email can't be blank"
+        end
+      end
+    end
+
+    describe 'マイページ' do
+      context 'ログインしていない状態' do
+        it 'マイページへのアクセスが失敗する' do
+          visit user_path(user)
+          expect(current_path).to eq login_path
+          expect(page).to have_content "Login required"
+        end
+      end
+    end
+
+  describe 'ログイン後' do
+    before do
+      login(user)
+    end
+    describe 'ユーザー編集' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの編集が成功する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: user.password
+          fill_in 'Password confirmation', with: user.password
+          click_button 'Update'
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "User was successfully updated."
+        end
+      end
+
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの編集が失敗する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: ""
+          fill_in 'Password', with: 'example'
+          fill_in 'Password confirmation', with: 'example'
+          click_button 'Update'
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "Email can't be blank"
+        end
+      end
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの編集が失敗する' do
+          visit edit_user_path(user)
+          fill_in 'Email', with: other_user.email
+          fill_in 'Password', with: 'example'
+          fill_in 'Password confirmation', with: 'example'
+          click_button 'Update'
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "Email has already been taken"
+        end
+      end
+
+      context '他ユーザーの編集ページにアクセス' do
+        it '編集ページへのアクセスに失敗する' do
+          visit edit_user_path(other_user)
+          expect(current_path).to eq user_path(user)
+          expect(page).to have_content "Forbidden access"
+        end
+      end
+    end
+
+    describe 'マイページ' do
+      context 'タスクを作成' do
+        it '新規作成したタスクが表示される' do
+          visit new_task_path
+          fill_in 'Title', with: task.title
+          fill_in 'Content', with: task.content
+          select task.status, from: 'Status'
+          fill_in 'Deadline', with: task.deadline
+          click_button 'Create Task'
+          expect(page).to have_content "Task was successfully created."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
表題の件ですが現在、Rspec編３ システムスペックの実装を行っております。

一点わからない点があり質問させていただきました。
FactoryBotをインストールし
```
FactoryBot.define do
  factory :task do
    sequence(:title) { |n| "書類作成#{n}" }
    content {"取引先に書類を作成する"}
    status { 'todo' }
    deadline { 1.week.from_now }
    association :user
  end
end
```
上記のように設定を行いusers_spec.rbで
```
let(:task){ create(:task)}
```
このようにletで定義した上で
```
 describe 'マイページ' do
      context 'タスクを作成' do
        it '新規作成したタスクが表示される' do
          visit new_task_path
          fill_in 'Title', with: task.title
          fill_in 'Content', with: task.content
          select task.status, from: 'Status'
          fill_in 'Deadline', with: task.deadline
          click_button 'Create Task'
          expect(page).to have_content "Task was successfully created."
        end
      end
    end
```
このようにテストを書き実行すると
https://i.gyazo.com/a2ac81640aeeaaec3316c4ff3a6be4a8.png
Title has already been taken　というエラーが発生します。

これに対してsequenceで定義しているのでtitleが被ることはないのではと考え、FactoryBotの記述ではなくDBのデータがテスト毎にリセットされてないのではと考えたのですがrails_helper.rbの下記記述に漏れもなく特に問題のないように思います
```
config.use_transactional_fixtures = true
```

テストの書き方に誤りがあるのでしょうか。
助言いただけると幸いです。